### PR TITLE
make gem_at_line regular expression stricter

### DIFF
--- a/lib/fix_mah_gemfile.rb
+++ b/lib/fix_mah_gemfile.rb
@@ -64,7 +64,7 @@ module FixMahGemfile
       end
     end
     def gem_at_line gemname
-      found = gemfile.index { |line| line =~ /^\s*gem ['|"]#{gemname}/ }
+      found = gemfile.index { |line| line =~ /^\s*gem ['|"]#{gemname}['|"]/ }
       puts "found at #{found}"
       if found
         puts gemfile[found]


### PR DESCRIPTION
since remove_gem 'pry' will accidentally remove 'pry-rails'